### PR TITLE
Improve compatibility with other frameworks and future OMF.

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,3 +1,9 @@
 set -q NDENV_ROOT; or set -l NDENV_ROOT $HOME/.ndenv
 
-set PATH $NDENV_ROOT/shims $NDENV_ROOT/bin $PATH
+if not contains $NDENV_ROOT/bin $PATH
+  set PATH $NDENV_ROOT/bin $PATH
+end
+
+if not contains $NDENV_ROOT/shims $PATH
+  set PATH $NDENV_ROOT/shims $PATH
+end

--- a/init.fish
+++ b/init.fish
@@ -1,0 +1,3 @@
+set -q NDENV_ROOT; or set -l NDENV_ROOT $HOME/.ndenv
+
+set PATH $NDENV_ROOT/shims $NDENV_ROOT/bin $PATH

--- a/ndenv.load
+++ b/ndenv.load
@@ -1,7 +1,0 @@
-if test -n "$NDENV_ROOT"
-  _prepend_path $NDENV_ROOT/bin
-  _prepend_path $NDENV_ROOT/shims
-else
-  _prepend_path $HOME/.ndenv/bin
-  _prepend_path $HOME/.ndenv/shims
-end


### PR DESCRIPTION
- Move initialization to `init.fish`, use fishier idioms.
- Only add missing paths during init.
